### PR TITLE
Make the formatter iterate over offences instead of Cops

### DIFF
--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -3,11 +3,6 @@ require 'rexml/document'
 module RuboCop
   module Formatter
     class JUnitFormatter < BaseFormatter
-
-      # This gives all cops - we really want all _enabled_ cops, but
-      # that is difficult to obtain - no access to config object here.
-      COPS = Cop::Cop.all
-      
       def started(target_file)
         @document = REXML::Document.new.tap do |d|
           d << REXML::XMLDecl.new
@@ -20,16 +15,16 @@ module RuboCop
 
       def file_finished(file, offences)
         # One test case per cop per file
-        COPS.each do |cop|
+        offences.group_by(&:cop_name).each do |cop_name, offences|
           REXML::Element.new('testcase', @testsuite).tap do |f|
             f.attributes['classname'] = file.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').gsub('/', '.')
-            f.attributes['name']      = cop.cop_name
-            
+            f.attributes['name']      = cop_name
+
             # One failure per offence.  Zero failures is a passing test case,
             # for most surefire/nUnit parsers.
-            offences.select {|offence| offence.cop_name == cop.cop_name}.each do |offence|
+            offences.each do |offence|
               REXML::Element.new('failure', f).tap do |e|
-                e.attributes['type'] = cop.cop_name
+                e.attributes['type'] = cop_name
                 e.attributes['message'] = offence.message
                 e.add_text offence.location.to_s
               end


### PR DESCRIPTION
Cop::Cop.all wasn't finding some cops, e.g. RSpec/MultipleExpectations, and so rubocop was failing with return code 1, but there were no style violations listed in the output XML file.